### PR TITLE
remove OpenStruct usage

### DIFF
--- a/lib/paypalhttp.rb
+++ b/lib/paypalhttp.rb
@@ -1,4 +1,5 @@
 module PayPalHttp
+  require_relative "paypalhttp/container"
   require_relative "paypalhttp/environment"
   require_relative "paypalhttp/http_client"
   require_relative "paypalhttp/errors"

--- a/lib/paypalhttp/container.rb
+++ b/lib/paypalhttp/container.rb
@@ -1,0 +1,47 @@
+module PayPalHttp
+
+  # the purpose of this class is to work around OpenStruct's inefficiency.
+  # it employs a more dynamic meta programming approach to prevent
+  # invalidation of ruby's global method cache.
+  # see https://mensfeld.pl/2015/04/ruby-global-method-cache-invalidation-impact-on-a-single-and-multithreaded-applications/
+  class Container
+    attr_reader :attributes
+
+    def initialize(attributes = {})
+      @attributes = attributes
+    end
+
+    def respond_to? meth
+      @attributes.key?(meth) || attribute_writer?(meth) || super
+    end
+
+    def method_missing(meth, *args, &blk)
+      if attribute_writer?(meth)
+        key = meth.to_s.tr('=', '').to_sym
+        @attributes[key] = args.first
+      elsif key = attributes_key(meth)
+        @attributes[key]
+      else
+        super
+      end
+    end
+
+    def []=(key, value)
+      @attributes[key] = value
+    end
+
+    def [](key)
+      @attributes[key]
+    end
+
+    protected
+
+      def attribute_writer?(meth)
+        meth.to_s.end_with?("=")
+      end
+
+      def attributes_key(meth)
+        [ meth.to_sym, meth.to_s ].detect { |k| @attributes.key?(k) }
+      end
+  end
+end

--- a/lib/paypalhttp/http_client.rb
+++ b/lib/paypalhttp/http_client.rb
@@ -1,4 +1,3 @@
-require 'ostruct'
 require 'net/http'
 require 'date'
 
@@ -45,7 +44,7 @@ module PayPalHttp
     def execute(req)
       headers = req.headers || {}
 
-      request = OpenStruct.new({
+      request = Container.new({
         :verb => req.verb,
         :path => req.path,
         :headers => headers.clone,
@@ -98,7 +97,7 @@ module PayPalHttp
         result = nil
       end
 
-      obj = OpenStruct.new({
+      obj = Container.new({
         :status_code => status_code,
         :result => result,
         :headers => response.to_hash,
@@ -120,7 +119,7 @@ module PayPalHttp
           obj << _parse_values(v)
         end
       elsif values.is_a?(Hash)
-        obj = OpenStruct.new()
+        obj = Container.new()
         values.each do |k, v|
           obj[k] = _parse_values(v)
         end


### PR DESCRIPTION
this pr removes `OpenStruct` from runtime logic. 

`OpenStruct` defines methods at runtime and by that invalidates the global method cache which can impose quite a significant performance penalty as [demonstrated here](https://mensfeld.pl/2015/04/ruby-global-method-cache-invalidation-impact-on-a-single-and-multithreaded-applications/) and [there](https://github.com/charliesome/charlie.bz/blob/master/posts/things-that-clear-rubys-method-cache.md). this is critical using it in larger rails applications, for example.

there have been patches proposed ([9262][9262], [8426][8426], [7816][7816]) to mri but as far as i can see no real progress was made.

also, [this reddit thread](https://www.reddit.com/r/ruby/comments/99d6ku/openstruct_in_ruby/) is quite insightful with comments as recent as 1 year ago.

[9262]: https://bugs.ruby-lang.org/issues/9262
[8426]: https://bugs.ruby-lang.org/issues/8426
[7816]: https://bugs.ruby-lang.org/issues/7816