### PR TITLE
Replaces URI.escape to fix Ruby 2.7 deprecation warning

### DIFF
--- a/lib/paypalhttp/serializers/form_encoded.rb
+++ b/lib/paypalhttp/serializers/form_encoded.rb
@@ -5,7 +5,7 @@ module PayPalHttp
     def encode(request)
       encoded_params = []
       request.body.each do |k, v|
-        encoded_params.push("#{URI.escape(k.to_s)}=#{URI.escape(v.to_s)}")
+        encoded_params.push("#{encode_part(k)}=#{encode_part(v)}")
       end
 
       encoded_params.join("&")
@@ -17,6 +17,12 @@ module PayPalHttp
 
     def content_type
       /^application\/x-www-form-urlencoded/
+    end
+
+    private
+
+    def encode_part(part)
+      URI.encode_www_form_component(part.to_s)
     end
   end
 end

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -105,7 +105,7 @@ describe Encoder do
       })
       serialized = Encoder.new.serialize_request(req)
 
-      expect(serialized).to eq("key=value%20with%20a%20space&another_key=1013")
+      expect(serialized).to eq("key=value+with+a+space&another_key=1013")
     end
 
     it 'throws when content-type is unsupported' do


### PR DESCRIPTION
Using URI.encode_www_form_component instead.