### PR TITLE
Downcase content-type header because PayPal started sending "JSON"

### DIFF
--- a/lib/paypalhttp/encoder.rb
+++ b/lib/paypalhttp/encoder.rb
@@ -15,7 +15,7 @@ module PayPalHttp
     def serialize_request(req)
       raise UnsupportedEncodingError.new('HttpRequest did not have Content-Type header set') unless req.headers && (req.headers['content-type'])
 
-      content_type = _extract_header(req.headers, 'content-type')
+      content_type = _extract_header(req.headers, 'content-type').downcase
 
       enc = _encoder(content_type)
       raise UnsupportedEncodingError.new("Unable to serialize request with Content-Type #{content_type}. Supported encodings are #{supported_encodings}") unless enc
@@ -40,7 +40,7 @@ module PayPalHttp
     def deserialize_response(resp, headers)
       raise UnsupportedEncodingError.new('HttpResponse did not have Content-Type header set') unless headers && (headers['content-type'])
 
-      content_type = _extract_header(headers, 'content-type')
+      content_type = _extract_header(headers, 'content-type').downcase
 
       enc = _encoder(content_type)
       raise UnsupportedEncodingError.new("Unable to deserialize response with Content-Type #{content_type}. Supported decodings are #{supported_encodings}") unless enc

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -205,6 +205,27 @@ describe Encoder do
       expect(deserialized).to eq(expected)
     end
 
+    it 'deserializes the response when content-type == application/JSON' do
+      expected = {
+        "string" => "value",
+        "number" => 1.23,
+        "bool" => true,
+        "array" => ["one", "two", "three"],
+        "nested" => {
+          "nested_string" => "nested_value",
+          "nested_array" => [1,2,3]
+        }
+      }
+
+      headers = {"content-type" => ["application/JSON; charset=utf8"]}
+      body = '{"string":"value","number":1.23,"bool":true,"array":["one","two","three"],"nested":{"nested_string":"nested_value","nested_array":[1,2,3]}}'
+
+      deserialized = Encoder.new.deserialize_response(body, headers)
+
+      expect(deserialized).to eq(expected)
+    end
+
+
     it 'deserializes the response when content-type == text/*' do
       headers = {"content-type" => ["text/plain; charset=utf8"]}
       body = 'some text'


### PR DESCRIPTION
Starting today, we started seeing these errors:

```
PayPalHttp::UnsupportedEncodingError: Unable to deserialize response with Content-Type application/JSON. Supported decodings are ["/application\\/json/", "/text\\/.*/", "/multipart\\/.*/", "/^application\\/x-www-form-urlencoded/"]
```

Downcasing the content-type header value seems harmless