### PR TITLE
Fix content_type for application/JSON (change from case sensitive to case insensitive)

### DIFF
--- a/lib/paypalhttp/serializers/json.rb
+++ b/lib/paypalhttp/serializers/json.rb
@@ -11,7 +11,7 @@ module PayPalHttp
     end
 
     def content_type
-      /application\/json/
+      /application\/json/i
     end
   end
 end

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -205,6 +205,26 @@ describe Encoder do
       expect(deserialized).to eq(expected)
     end
 
+    it 'deserializes the response when content-type == application/JSON' do
+      expected = {
+        "string" => "value",
+        "number" => 1.23,
+        "bool" => true,
+        "array" => ["one", "two", "three"],
+        "nested" => {
+          "nested_string" => "nested_value",
+          "nested_array" => [1,2,3]
+        }
+      }
+
+      headers = {"content-type" => ["application/JSON; charset=utf8"]}
+      body = '{"string":"value","number":1.23,"bool":true,"array":["one","two","three"],"nested":{"nested_string":"nested_value","nested_array":[1,2,3]}}'
+
+      deserialized = Encoder.new.deserialize_response(body, headers)
+
+      expect(deserialized).to eq(expected)
+    end
+
     it 'deserializes the response when content-type == text/*' do
       headers = {"content-type" => ["text/plain; charset=utf8"]}
       body = 'some text'


### PR DESCRIPTION
# Summary

There is an ongoing bug with PayPal's SDK which relies on PayPal's **paypalhttp_ruby** gem which will throw an exception when receiving "application/JSON". It should just handle it like "application/json" so here is a fix.

The **Payouts-Ruby-SDK** gem will also need to be forked and updated to use this version of the **paypalhttp_ruby** gem and then we can point our applications to use the forked **Payouts-Ruby-SDK** gem. 

Right now I am just waiting for some confirmation that we can indeed fork the SDK gem as it does not have the MIT license.