### PR TITLE
Add Support for Ruby 3.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,4 +68,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.4
+   2.2.25

--- a/lib/paypalhttp/serializers/form_encoded.rb
+++ b/lib/paypalhttp/serializers/form_encoded.rb
@@ -1,11 +1,11 @@
-require 'uri'
+require 'cgi'
 
 module PayPalHttp
   class FormEncoded
     def encode(request)
       encoded_params = []
       request.body.each do |k, v|
-        encoded_params.push("#{URI.escape(k.to_s)}=#{URI.escape(v.to_s)}")
+        encoded_params.push("#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}")
       end
 
       encoded_params.join("&")


### PR DESCRIPTION
*Issue*

Ruby 3.x removed support for URI::Escape, which is used in the form_encoded serialize.

*Resolution*

Replaced URI:Escape with CGI:Escape