### PR TITLE
Hdl 285 paypal sdk header: Fixing Case Sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.1
+* Fix Case Sensitivity of Content Type for deserialization process
+
+## 1.0.0
+* Fix Case Sensitivity of Acessing Headers by formatting beforehand
+
 ## 0.5.0
 * Add support for multipart/form-data file uploads with JSON content FormParts.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2019 PayPal, Inc.
+Copyright (c) 2009-2021 PayPal, Inc.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/lib/paypalhttp/encoder.rb
+++ b/lib/paypalhttp/encoder.rb
@@ -41,6 +41,7 @@ module PayPalHttp
       raise UnsupportedEncodingError.new('HttpResponse did not have Content-Type header set') unless headers && (headers['content-type'])
 
       content_type = _extract_header(headers, 'content-type')
+      content_type.downcase!
 
       enc = _encoder(content_type)
       raise UnsupportedEncodingError.new("Unable to deserialize response with Content-Type #{content_type}. Supported decodings are #{supported_encodings}") unless enc

--- a/lib/paypalhttp/http_client.rb
+++ b/lib/paypalhttp/http_client.rb
@@ -28,7 +28,13 @@ module PayPalHttp
     def format_headers(headers)
       formatted_headers = {}
       headers.each do |key, value|
-        formatted_headers[key.downcase] = value
+        # TODO: Since header is treated as a hash, val is in an array.
+        # Will this cause an issue when accessing and modifying val
+        # Ensure this is the case and will not propegate access issues/errors
+        if key.casecmp("content-type") == 0
+          value[0].downcase!
+        end
+          formatted_headers[key.downcase] = value
       end
       formatted_headers
     end

--- a/lib/paypalhttp/version.rb
+++ b/lib/paypalhttp/version.rb
@@ -1,1 +1,1 @@
-VERSION = "1.0.0"
+VERSION = "1.0.1"

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -205,8 +205,35 @@ describe Encoder do
       expect(deserialized).to eq(expected)
     end
 
+    it 'deserializes the response when content-type == application/json: case insensitive' do
+      expected = {
+        "string" => "value",
+        "number" => 1.23,
+        "bool" => true,
+        "array" => ["one", "two", "three"],
+        "nested" => {
+          "nested_string" => "nested_value",
+          "nested_array" => [1,2,3]
+        }
+      }
+
+      headers = {"content-type" => ["application/JSON; charset=utf8"]}
+      body = '{"string":"value","number":1.23,"bool":true,"array":["one","two","three"],"nested":{"nested_string":"nested_value","nested_array":[1,2,3]}}'
+
+      deserialized = Encoder.new.deserialize_response(body, headers)
+
+      expect(deserialized).to eq(expected)
+    end
+
     it 'deserializes the response when content-type == text/*' do
       headers = {"content-type" => ["text/plain; charset=utf8"]}
+      body = 'some text'
+
+      expect(Encoder.new.deserialize_response(body, headers)).to eq('some text')
+    end
+
+    it 'deserializes the response when content-type == text/*: case insensitive' do
+      headers = {"content-type" => ["TEXT/plain; charset=utf8"]}
       body = 'some text'
 
       expect(Encoder.new.deserialize_response(body, headers)).to eq('some text')

--- a/spec/paypalhttp/http_client_spec.rb
+++ b/spec/paypalhttp/http_client_spec.rb
@@ -226,6 +226,57 @@ describe HttpClient do
     expect(resp.result).to eq(return_data)
   end
 
+  it 'handles json array result: case insensitive' do
+    WebMock.enable!
+
+    return_data = ["one", "two"]
+
+    http_client = HttpClient.new(@environment)
+
+    stub_request(:get, @environment.base_url + "/v1/api")
+      .to_return(body: JSON.generate(return_data), status: 200, headers: {"Content-Type" => "application/JSON"})
+
+    req = OpenStruct.new({:verb => "GET", :path => "/v1/api"})
+
+    resp = http_client.execute(req)
+
+    expect(resp.result).to eq(return_data)
+  end
+
+  it 'handles plain text result' do
+    WebMock.enable!
+
+    return_data = "value"
+
+    http_client = HttpClient.new(@environment)
+
+    stub_request(:get, @environment.base_url + "/v1/api")
+      .to_return(body: return_data, status: 200, headers: {"Content-Type" => "text/plain; charset=utf8"})
+
+    req = OpenStruct.new({:verb => "GET", :path => "/v1/api"})
+
+    resp = http_client.execute(req)
+
+    expect(resp.result).to eq(return_data)
+  end
+
+  it 'handles plain text result: case insensitive' do
+    WebMock.enable!
+
+    return_data = "value"
+
+    http_client = HttpClient.new(@environment)
+
+    stub_request(:get, @environment.base_url + "/v1/api")
+      .to_return(body: return_data, status: 200, headers: {"Content-Type" => "TEXT/plain; charset=utf8"})
+
+    req = OpenStruct.new({:verb => "GET", :path => "/v1/api"})
+
+    resp = http_client.execute(req)
+
+    expect(resp.result).to eq(return_data)
+  end
+
   it 'deserializes nested response object into nested openstruct response' do
     WebMock.enable!
 


### PR DESCRIPTION
Internal Change for Ticket 285: 

Author: hlahlou

Changes made in Encoder and HttpClient to force the value for Content-Type to lowercase.

Added Unit Tests to ensure that deserialization and execution of HTTP request were case insensitive and could handle Content-Types of different casing (ex: application/json vs application/JSON)

Also updated the license, change log, and version to reflect changes made and to update copyright.


Results of Unit Tests:
<img width="1792" alt="Screen Shot 2021-08-25 at 1 17 21 PM" src="https://user-images.githubusercontent.com/30755392/130838943-45bc6a4e-2514-47f9-ad11-37bf3600892c.png">

Integration Test Results with Checkout SDK:
<img width="1792" alt="Screen Shot 2021-08-30 at 6 40 55 PM" src="https://user-images.githubusercontent.com/30755392/131736302-168f6ebe-3935-4751-b2d8-b452f0573338.png">
