### PR TITLE
Handle frozen strings in headers

### DIFF
--- a/lib/paypalhttp/encoder.rb
+++ b/lib/paypalhttp/encoder.rb
@@ -40,8 +40,7 @@ module PayPalHttp
     def deserialize_response(resp, headers)
       raise UnsupportedEncodingError.new('HttpResponse did not have Content-Type header set') unless headers && (headers['content-type'])
 
-      content_type = _extract_header(headers, 'content-type')
-      content_type.downcase!
+      content_type = _extract_header(headers, 'content-type').downcase
 
       enc = _encoder(content_type)
       raise UnsupportedEncodingError.new("Unable to deserialize response with Content-Type #{content_type}. Supported decodings are #{supported_encodings}") unless enc

--- a/lib/paypalhttp/http_client.rb
+++ b/lib/paypalhttp/http_client.rb
@@ -26,11 +26,7 @@ module PayPalHttp
     end
 
     def format_headers(headers)
-      formatted_headers = {}
-      headers.each do |key, value|
-        formatted_headers[key.downcase] = value
-      end
-      formatted_headers
+      headers.transform_keys(&:downcase)
     end
 
     def map_headers(raw_headers , formatted_headers)

--- a/lib/paypalhttp/http_client.rb
+++ b/lib/paypalhttp/http_client.rb
@@ -28,13 +28,7 @@ module PayPalHttp
     def format_headers(headers)
       formatted_headers = {}
       headers.each do |key, value|
-        # TODO: Since header is treated as a hash, val is in an array.
-        # Will this cause an issue when accessing and modifying val
-        # Ensure this is the case and will not propegate access issues/errors
-        if key.casecmp("content-type") == 0
-          value[0].downcase!
-        end
-          formatted_headers[key.downcase] = value
+        formatted_headers[key.downcase] = value
       end
       formatted_headers
     end

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -225,6 +225,14 @@ describe Encoder do
       expect(deserialized).to eq(expected)
     end
 
+    it 'handles frozen header fields' do
+      headers = {"content-type".freeze => ["application/JSON; charset=utf8".freeze]}
+
+      deserialized = Encoder.new.deserialize_response('{}', headers)
+
+      expect(deserialized).to eq({})
+    end
+
     it 'deserializes the response when content-type == text/*' do
       headers = {"content-type" => ["text/plain; charset=utf8"]}
       body = 'some text'

--- a/spec/paypalhttp/http_client_spec.rb
+++ b/spec/paypalhttp/http_client_spec.rb
@@ -330,6 +330,23 @@ describe HttpClient do
 		rescue Exception => e
 			fail e.message
 		end
-	end
+  end
+
+  it 'handles frozen header fields' do
+    WebMock.enable!
+
+    return_data = ["one", "two"]
+
+    http_client = HttpClient.new(@environment)
+
+    stub_request(:get, @environment.base_url + "/v1/api")
+      .to_return(body: JSON.generate(return_data), status: 200, headers: {"Content-Type".freeze => "application/JSON".freeze})
+
+    req = OpenStruct.new({:verb => "GET", :path => "/v1/api"})
+
+    resp = http_client.execute(req)
+
+    expect(resp.result).to eq(return_data)
+  end
 end
 


### PR DESCRIPTION
Since version 1.0.1 paypalhttp_ruby no longer works when using WebMock for testing along with frozen strings  Closes #14. 