### PR TITLE
Support ruby 3.0 with the removal of URI.escape

### DIFF
--- a/lib/paypalhttp/serializers/form_encoded.rb
+++ b/lib/paypalhttp/serializers/form_encoded.rb
@@ -5,7 +5,7 @@ module PayPalHttp
     def encode(request)
       encoded_params = []
       request.body.each do |k, v|
-        encoded_params.push("#{URI.escape(k.to_s)}=#{URI.escape(v.to_s)}")
+        encoded_params.push("#{escape(k)}=#{escape(v)}")
       end
 
       encoded_params.join("&")
@@ -17,6 +17,12 @@ module PayPalHttp
 
     def content_type
       /^application\/x-www-form-urlencoded/
+    end
+    
+    private
+    
+    def escape(value)
+      URI.encode_www_form_component(value.to_s).gsub('+', '%20')
     end
   end
 end


### PR DESCRIPTION
Otherwise I get:

```
/Users/dorianmariefr/.rvm/gems/ruby-3.0.3/gems/paypalhttp-1.0.1/lib/paypalhttp/serializers/form_encoded.rb:8:in `block in encode': undefined method `escape' for URI:Module (NoMethodError)
```