### PR TITLE
Changed URI.escape to CGI.escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.2
+* Change URI.escape to CGI.escape which changes form encoding for spaces from "%20" to "+".
+
 ## 1.0.1
 * Fix Case Sensitivity of Content Type for deserialization process
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.2
+## 2.0.0
 * Change URI.escape to CGI.escape which changes form encoding for spaces from "%20" to "+".
 
 ## 1.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,4 +68,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.25
+   1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,4 +68,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.4
+   2.2.25

--- a/lib/paypalhttp/serializers/form_encoded.rb
+++ b/lib/paypalhttp/serializers/form_encoded.rb
@@ -1,11 +1,11 @@
-require 'uri'
+require 'cgi'
 
 module PayPalHttp
   class FormEncoded
     def encode(request)
       encoded_params = []
       request.body.each do |k, v|
-        encoded_params.push("#{URI.escape(k.to_s)}=#{URI.escape(v.to_s)}")
+        encoded_params.push("#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}")
       end
 
       encoded_params.join("&")

--- a/lib/paypalhttp/version.rb
+++ b/lib/paypalhttp/version.rb
@@ -1,1 +1,1 @@
-VERSION = "1.0.1"
+VERSION = "1.0.2"

--- a/lib/paypalhttp/version.rb
+++ b/lib/paypalhttp/version.rb
@@ -1,1 +1,1 @@
-VERSION = "1.0.2"
+VERSION = "2.0.0"

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -105,7 +105,7 @@ describe Encoder do
       })
       serialized = Encoder.new.serialize_request(req)
 
-      expect(serialized).to eq("key=value%20with%20a%20space&another_key=1013")
+      expect(serialized).to eq("key=value+with+a+space&another_key=1013")
     end
 
     it 'throws when content-type is unsupported' do

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -108,6 +108,23 @@ describe Encoder do
       expect(serialized).to eq("key=value+with+a+space&another_key=1013")
     end
 
+    it 'encodes different special/unsafe characters when using CGI.escape' do
+      req = OpenStruct.new({
+        :verb => "POST",
+        :path => "/v1/api",
+        :headers => {
+          "content-type" => "application/x-www-form-urlencoded; charset=utf8"
+        },
+        :body => {
+          :key => " ..<..>..%..{..}..|../..^..`..!",
+          :another_key => 1013,
+        }
+      })
+      serialized = Encoder.new.serialize_request(req)
+
+      expect(serialized).to eq("key=+..%3C..%3E..%25..%7B..%7D..%7C..%2F..%5E..%60..%21&another_key=1013")
+    end
+
     it 'throws when content-type is unsupported' do
       req = OpenStruct.new({
         :headers  => {


### PR DESCRIPTION
- In Ruby version 3.x, the `URI.escape` function becomes deprecated, causing issues that many users will run into.
- Changed the `URI.escape` function to become `CGI.escape` as it is more consistent with other projects such as [braintree_ruby](https://github.com/braintree/braintree_ruby).
- With this change, the space character now becomes a `+`, instead of previously being `%20`.
    - There are also other special/unsafe characters that are also encoded which is showcased below.

- Verified that the deprecation warning logs that appeared in _2.x_ do not appear in Ruby version _3.x_ when running tests:
<img width="1418" alt="Screen Shot 2022-06-14 at 11 51 59 AM" src="https://user-images.githubusercontent.com/12592121/173666829-3453a631-8197-40d3-86c9-4f5feacc7ca7.png">

- Integration tested this change with the [PayPal Checkout-Ruby-SDK](https://github.com/paypal/Checkout-Ruby-SDK) and displayed no failures in unit tests.
   - Manually entered in test strings in the access token request body: https://github.com/paypal/Checkout-Ruby-SDK/blob/develop/lib/core/token_requests.rb#L7-L9
   - Temporarily added a print statement in the `FormEncoded.rb` file to view the results of the CGI.escape workings.
<img width="1275" alt="image" src="https://user-images.githubusercontent.com/12592121/173919311-31c1e8b4-ae74-4e03-8e0b-146eb108ad71.png">

