### PR TITLE
Fix/CGI.escape Function Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.1 (unreleased)
+## 2.0.1
 * Fix form encoded by replacing CGI.escape with URI parser.
 
 ## 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1 (unreleased)
+* Fix form encoded by replacing CGI.escape with URI parser.
+
 ## 2.0.0
 * Change URI.escape to CGI.escape which changes form encoding for spaces from "%20" to "+".
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.2
+* Change URI.escape to CGI.escape which changes form encoding for spaces from "%20" to "+".
+
 ## 1.0.1
 * Fix Case Sensitivity of Content Type for deserialization process
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.2
+## 2.0.0
 * Change URI.escape to CGI.escape which changes form encoding for spaces from "%20" to "+".
 
 ## 1.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,4 +68,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.25
+   1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,4 +68,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.4
+   2.2.25

--- a/lib/paypalhttp/serializers/form_encoded.rb
+++ b/lib/paypalhttp/serializers/form_encoded.rb
@@ -1,11 +1,11 @@
-require 'uri'
+require 'cgi'
 
 module PayPalHttp
   class FormEncoded
     def encode(request)
       encoded_params = []
       request.body.each do |k, v|
-        encoded_params.push("#{URI.escape(k.to_s)}=#{URI.escape(v.to_s)}")
+        encoded_params.push("#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}")
       end
 
       encoded_params.join("&")

--- a/lib/paypalhttp/serializers/form_encoded.rb
+++ b/lib/paypalhttp/serializers/form_encoded.rb
@@ -3,7 +3,7 @@ require 'uri'
 module PayPalHttp
   class FormEncoded
     def initialize
-      @parser = parser = URI::Parser.new()
+      @parser = URI::Parser.new()
     end
 
     def encode(request)

--- a/lib/paypalhttp/serializers/form_encoded.rb
+++ b/lib/paypalhttp/serializers/form_encoded.rb
@@ -4,8 +4,9 @@ module PayPalHttp
   class FormEncoded
     def encode(request)
       encoded_params = []
+      parser = URI::Parser.new()
       request.body.each do |k, v|
-        encoded_params.push("#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}")
+        encoded_params.push("#{parser.escape(k.to_s)}=#{parser.escape(v.to_s)}")
       end
 
       encoded_params.join("&")

--- a/lib/paypalhttp/serializers/form_encoded.rb
+++ b/lib/paypalhttp/serializers/form_encoded.rb
@@ -2,11 +2,14 @@ require 'uri'
 
 module PayPalHttp
   class FormEncoded
+    def initialize
+      @parser = parser = URI::Parser.new()
+    end
+
     def encode(request)
       encoded_params = []
-      parser = URI::Parser.new()
       request.body.each do |k, v|
-        encoded_params.push("#{parser.escape(k.to_s)}=#{parser.escape(v.to_s)}")
+        encoded_params.push("#{@parser.escape(k.to_s)}=#{@parser.escape(v.to_s)}")
       end
 
       encoded_params.join("&")

--- a/lib/paypalhttp/version.rb
+++ b/lib/paypalhttp/version.rb
@@ -1,1 +1,1 @@
-VERSION = "2.0.0"
+VERSION = "2.0.1"

--- a/lib/paypalhttp/version.rb
+++ b/lib/paypalhttp/version.rb
@@ -1,1 +1,1 @@
-VERSION = "1.0.1"
+VERSION = "1.0.2"

--- a/lib/paypalhttp/version.rb
+++ b/lib/paypalhttp/version.rb
@@ -1,1 +1,1 @@
-VERSION = "1.0.2"
+VERSION = "2.0.0"

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -105,7 +105,7 @@ describe Encoder do
       })
       serialized = Encoder.new.serialize_request(req)
 
-      expect(serialized).to eq("key=value%20with%20a%20space&another_key=1013")
+      expect(serialized).to eq("key=value+with+a+space&another_key=1013")
     end
 
     it 'throws when content-type is unsupported' do

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -108,7 +108,7 @@ describe Encoder do
       expect(serialized).to eq("key=value%20with%20a%20space&another_key=1013")
     end
 
-    it 'encodes different special/unsafe characters when using CGI.escape' do
+    it 'encodes different special/unsafe characters when using a URI parser' do
       req = OpenStruct.new({
         :verb => "POST",
         :path => "/v1/api",
@@ -116,30 +116,13 @@ describe Encoder do
           "content-type" => "application/x-www-form-urlencoded; charset=utf8"
         },
         :body => {
-          :key => " ..<..>..%..{..}..|..^..`",
+          :key => " ..<..>..%..{..}..|..^..`..!",
           :another_key => 1013,
         }
       })
       serialized = Encoder.new.serialize_request(req)
 
-      expect(serialized).to eq("key=%20..%3C..%3E..%25..%7B..%7D..%7C..%5E..%60&another_key=1013")
-    end
-
-    it 'encodes different special/unsafe characters when using CGI.escape' do
-      req = OpenStruct.new({
-        :verb => "POST",
-        :path => "/v1/api",
-        :headers => {
-          "content-type" => "application/x-www-form-urlencoded; charset=utf8"
-        },
-        :body => {
-          :key => " ..<..>..%..{..}..|..^..`",
-          :another_key => 1013,
-        }
-      })
-      serialized = Encoder.new.serialize_request(req)
-
-      expect(serialized).to eq("key=%20..%3C..%3E..%25..%7B..%7D..%7C..%5E..%60&another_key=1013")
+      expect(serialized).to eq("key=%20..%3C..%3E..%25..%7B..%7D..%7C..%5E..%60..!&another_key=1013")
     end
 
     it 'does not encode links given certain special characters' do

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -105,7 +105,7 @@ describe Encoder do
       })
       serialized = Encoder.new.serialize_request(req)
 
-      expect(serialized).to eq("key=value+with+a+space&another_key=1013")
+      expect(serialized).to eq("key=value%20with%20a%20space&another_key=1013")
     end
 
     it 'encodes different special/unsafe characters when using CGI.escape' do
@@ -116,13 +116,29 @@ describe Encoder do
           "content-type" => "application/x-www-form-urlencoded; charset=utf8"
         },
         :body => {
-          :key => " ..<..>..%..{..}..|../..^..`..!",
+          :key => " ..<..>..%..{..}..|..^..`",
           :another_key => 1013,
         }
       })
       serialized = Encoder.new.serialize_request(req)
 
-      expect(serialized).to eq("key=+..%3C..%3E..%25..%7B..%7D..%7C..%2F..%5E..%60..%21&another_key=1013")
+      expect(serialized).to eq("key=%20..%3C..%3E..%25..%7B..%7D..%7C..%5E..%60&another_key=1013")
+    end
+
+    it 'does not encode links given certain special characters' do
+      req = OpenStruct.new({
+        :verb => "POST",
+        :path => "/v1/api",
+        :headers => {
+          "content-type" => "application/x-www-form-urlencoded; charset=utf8"
+        },
+        :body => {
+          :key => "https://localhost:3001/"
+        }
+      })
+      serialized = Encoder.new.serialize_request(req)
+
+      expect(serialized).to eq("key=https://localhost:3001/")
     end
 
     it 'throws when content-type is unsupported' do

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -105,7 +105,7 @@ describe Encoder do
       })
       serialized = Encoder.new.serialize_request(req)
 
-      expect(serialized).to eq("key=value+with+a+space&another_key=1013")
+      expect(serialized).to eq("key=value%20with%20a%20space&another_key=1013")
     end
 
     it 'encodes different special/unsafe characters when using CGI.escape' do
@@ -116,13 +116,13 @@ describe Encoder do
           "content-type" => "application/x-www-form-urlencoded; charset=utf8"
         },
         :body => {
-          :key => " ..<..>..%..{..}..|../..^..`..!",
+          :key => " ..<..>..%..{..}..|..^..`",
           :another_key => 1013,
         }
       })
       serialized = Encoder.new.serialize_request(req)
 
-      expect(serialized).to eq("key=+..%3C..%3E..%25..%7B..%7D..%7C..%2F..%5E..%60..%21&another_key=1013")
+      expect(serialized).to eq("key=%20..%3C..%3E..%25..%7B..%7D..%7C..%5E..%60&another_key=1013")
     end
 
     it 'encodes different special/unsafe characters when using CGI.escape' do

--- a/spec/paypalhttp/encoder_spec.rb
+++ b/spec/paypalhttp/encoder_spec.rb
@@ -108,6 +108,23 @@ describe Encoder do
       expect(serialized).to eq("key=value+with+a+space&another_key=1013")
     end
 
+    it 'encodes different special/unsafe characters when using CGI.escape' do
+      req = OpenStruct.new({
+        :verb => "POST",
+        :path => "/v1/api",
+        :headers => {
+          "content-type" => "application/x-www-form-urlencoded; charset=utf8"
+        },
+        :body => {
+          :key => " ..<..>..%..{..}..|../..^..`..!",
+          :another_key => 1013,
+        }
+      })
+      serialized = Encoder.new.serialize_request(req)
+
+      expect(serialized).to eq("key=+..%3C..%3E..%25..%7B..%7D..%7C..%2F..%5E..%60..%21&another_key=1013")
+    end
+
     it 'throws when content-type is unsupported' do
       req = OpenStruct.new({
         :headers  => {


### PR DESCRIPTION
# Overview

- Previously there was a change to the `URI.escape` function to utilize `CGI.escape` as shown in this Pull Request: https://github.com/paypal/paypalhttp_ruby/pull/19. 
- There was a breaking case with this change, and this PR serves to resolve this.
    - Links such as `https://localhost:3001/` were having the special characters be encoded, resulting in `http%3A%2F%2Flocalhost%3A3001%2F` which is incorrect. 
- This change also reverts the functionality for encoding spaces, as CGI would make " " => "+" while this URI Parser replaces spaces with " " => "%20"
----
# Testing

- Updated unit tests and added a new one to showcase the passing functionality:
![RUBYHTTP_PR_IMAGE](https://user-images.githubusercontent.com/107945402/180893118-c9db8fd4-2adb-43cb-8ab0-03dca1047986.png)

- Integration tested this change with the [PayPal Checkout-Ruby-SDK](https://github.com/paypal/Checkout-Ruby-SDK) with Ruby version 3.0.4 and displayed no failures in unit tests.
    - Manually entered in test strings in the access token request body: https://github.com/paypal/Checkout-Ruby-SDK/blob/develop/lib/core/token_requests.rb#L7-L9
    - Temporarily added a print statement in the FormEncoded.rb file to view the results of the CGI.escape workings.

![RUBY_PR_IMAGE](https://user-images.githubusercontent.com/107945402/180893163-043fe7b5-e5d9-45cf-bf48-6a03e286efe1.png)
